### PR TITLE
Error "Problem starting container" when using repackaged Karaf distribution

### DIFF
--- a/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/ArchiveExtractor.java
+++ b/containers/pax-exam-container-karaf/src/main/java/org/ops4j/pax/exam/karaf/container/internal/ArchiveExtractor.java
@@ -110,7 +110,6 @@ public class ArchiveExtractor {
             ArchiveEntry entry = is.getNextEntry();
             while (entry != null) {
                 String name = entry.getName();
-                name = name.substring(name.indexOf("/") + 1);
                 File file = new File(targetDir, name);
                 if (entry.isDirectory()) {
                     file.mkdirs();


### PR DESCRIPTION
I've already described my problem in https://ops4j1.jira.com/browse/PAXEXAM-615.

This patch doesn't influence the normal behaviour for standard Karaf distributions but enables also packaged distributions to work with your plugin.
It would really help me if this patch could be included because otherwise I would have to refactor my whole build process. So please inlcude it, if it's at all possible!
